### PR TITLE
Update requirements in SwiftLint

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -6,7 +6,7 @@
     ],
     "swiftlint_supported_version": {
         "5.9": "main",
-        "5.8": "main",
-        "5.7": "main"
+        "5.8": "0.52.4",
+        "5.7": "0.52.4"
     }
 }


### PR DESCRIPTION
Since [0.53.0](https://github.com/realm/SwiftLint/releases/tag/0.53.0) it now requires Swift 5.9.

**Note**
There is no mention in currently in the release notes.
ref: https://github.com/realm/SwiftLint/issues/5267